### PR TITLE
test: use non-destructive runner for readonly suite

### DIFF
--- a/tests/post_deploy_functional_readonly/main_test.go
+++ b/tests/post_deploy_functional_readonly/main_test.go
@@ -33,5 +33,5 @@ func TestLambdaLayerModule(t *testing.T) {
 		SetTestConfigFileName(infraTFVarFileNameDefault).
 		Build()
 
-	lib.RunSetupTestTeardown(t, *ctx, testimpl.TestComposableComplete)
+	lib.RunNonDestructiveTest(t, *ctx, testimpl.TestComposableComplete)
 }


### PR DESCRIPTION
## What

The `tests/post_deploy_functional_readonly` suite called `lib.RunSetupTestTeardown`, which **applies and destroys** infrastructure — so the "read-only" suite was not actually read-only. This switches it to `lib.RunNonDestructiveTest`.

## Why it was invisible

`make test` excludes `post_deploy_functional_readonly` (`go list ./tests/... | grep -v post_deploy_functional_readonly`), so CI never runs this suite and the wrong runner passed unnoticed. Background: launchbynttdata/launch-workflows#92.

## Scope / safety

- One-line change. The testimpl function passed is **unchanged** and already satisfies the `TestComposable*` requirement of `RunNonDestructiveTest`.
- This is the proven-correct pairing used by passing modules across the fleet.

Part of a fleet-wide cleanup of converted-cohort "wrong runner" readonly suites (see #36 for the pilot).

Generated with [Claude Code](https://claude.com/claude-code)
